### PR TITLE
Fix: Correct hybrid retrieval and optimize performance

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,9 +29,9 @@ SERVER_HOST = os.environ.get("HOST", "0.0.0.0")
 SERVER_PORT = int(os.environ.get("PORT", "5000"))
 
 # --- Retrieval Configuration (defaults from query_llamaindex.py) ---
-RETRIEVAL_SIMILARITY_TOP_K = int(os.environ.get("RETRIEVAL_SIMILARITY_TOP_K", 30))
-RETRIEVAL_SPARSE_TOP_K = int(os.environ.get("RETRIEVAL_SPARSE_TOP_K", 10))
-RETRIEVAL_RERANK_TOP_N = int(os.environ.get("RETRIEVAL_RERANK_TOP_N", 50)) # 0 to disable
+RETRIEVAL_SIMILARITY_TOP_K = int(os.environ.get("RETRIEVAL_SIMILARITY_TOP_K", 25))
+RETRIEVAL_SPARSE_TOP_K = int(os.environ.get("RETRIEVAL_SPARSE_TOP_K", 7))
+RETRIEVAL_RERANK_TOP_N = int(os.environ.get("RETRIEVAL_RERANK_TOP_N", 20)) # 0 to disable
 RETRIEVAL_RERANKER_MODEL = os.environ.get("RETRIEVAL_RERANKER_MODEL", "cross-encoder/ms-marco-MiniLM-L-6-v2")
 RETRIEVAL_USE_HYBRID = os.environ.get("RETRIEVAL_USE_HYBRID", "True").lower() == "true"
 RETRIEVAL_USE_MMR = os.environ.get("RETRIEVAL_USE_MMR", "True").lower() == "true"


### PR DESCRIPTION
This commit addresses issues with slow retrieval times and ensures that hybrid retrieval (dense + sparse) functions correctly.

Key changes:

- query_llamaindex.py:
    - Replaced the incorrect `ListIndexRetriever` with a proper setup using `VectorIndexRetriever` (for Qdrant dense search) and `BM25Retriever` (for sparse search when enabled).
    - The custom `HybridRetriever` class is now correctly used to combine results from dense and sparse retrievers.
    - Added fallbacks to dense-only search if BM25Retriever cannot be initialized (e.g., due to an empty docstore).
    - Adjusted the `top_n` parameter for `MMRNodePostprocessor` to be dynamic based on whether hybrid search is active.
    - Added verbose logging to trace node counts from dense/sparse retrievers for easier verification of hybrid search.

- config.py:
    - Adjusted default retrieval parameters for better performance: - `RETRIEVAL_RERANK_TOP_N` changed from 50 to 20. - `RETRIEVAL_SIMILARITY_TOP_K` changed from 30 to 25. - `RETRIEVAL_SPARSE_TOP_K` changed from 10 to 7.

- README.md:
    - Updated default values for the aforementioned retrieval parameters.
    - Clarified that hybrid retrieval is implemented and working.
    - Added information about the `llama-index-retrievers-bm25` dependency for hybrid search functionality.

These changes should significantly improve retrieval performance and ensure that the hybrid search feature works as intended.